### PR TITLE
Check delete-staging only when the matrix is non-empty

### DIFF
--- a/.github/workflows/delete-staging.yaml
+++ b/.github/workflows/delete-staging.yaml
@@ -46,6 +46,7 @@ jobs:
             }
 
   delete-staging:
+    if: ${{ needs.setup.outputs.pull-request-numbers != '[]' }}
     runs-on: ubuntu-latest
     needs: setup
     strategy:


### PR DESCRIPTION
To solve this error:
https://github.com/yuya-takeyama/monorepo/actions/runs/716739178
>Error when evaluating 'strategy' for job 'delete-staging'. (Line: 53, Col: 30): Matrix vector 'pull-request-number' does not contain any values